### PR TITLE
Minor changes for MELPA readiness

### DIFF
--- a/spotify-client-api.el
+++ b/spotify-client-api.el
@@ -80,7 +80,7 @@ globally relevant."
 (defvar *spotify-client-api-oauth2-ts*    nil
   "Unix timestamp in which the OAuth2 token was retrieved.
 This is used to manually refresh the token when it's about to expire.")
-(defvar *spotify-client-api-oauth2-token-directory* "~/.emacs.d/.cache/spotify"
+(defvar *spotify-client-api-oauth2-token-directory* (concat (file-name-as-directory user-emacs-directory) ".local/cache/spotify")
 	"Directory where the OAuth2 token is serialized.")
 (defvar *spotify-client-api-oauth2-token-file* (concat *spotify-client-api-oauth2-token-directory* "/" "token")
 	"Location where the OAuth2 token is serialized.")
@@ -169,7 +169,7 @@ function that runs a local httpd for code -> token exchange."
 		(not (null *spotify-client-api-oauth2-token*))
 		(progn
 			(delete-file *spotify-client-api-oauth2-token-file*)
-			(make-empty-file *spotify-client-api-oauth2-token-file*)
+			(make-empty-file *spotify-client-api-oauth2-token-file* t)
 			t)
 		(with-temp-file *spotify-client-api-oauth2-token-file*
 			(prin1 `(,*spotify-client-api-oauth2-token* ,*spotify-client-api-oauth2-ts*) (current-buffer)))))

--- a/spotify-client-api.el
+++ b/spotify-client-api.el
@@ -11,18 +11,7 @@
 
 (require 'simple-httpd)
 (require 'request)
-
-;; Due to an issue related to compilation and the way oauth2 uses defadvice
-;; (including a FIXME as of 0.1.1), this declaration exists to prevent
-;; compiler warnings.
-(eval-when-compile
-  (defvar url-http-method nil)
-  (defvar url-http-data nil)
-  (defvar url-http-extra-headers nil)
-  (defvar oauth--token-data nil)
-  (defvar url-callback-function nil)
-  (defvar url-callback-arguments nil)
-  (require 'oauth2))
+(require 'oauth2)
 
 (defcustom spotify-client-oauth2-client-id ""
   "The unique identifier for your application.

--- a/spotify-client-track.el
+++ b/spotify-client-track.el
@@ -231,7 +231,7 @@ Default to sortin tracks by number when listing the tracks from an album."
                               (cons album-name
                                     (list 'face 'link
                                           'follow-link t
-                                          'action `(lambda (_) (spotify-client-album-tracks ,album))
+                                          'action `(lambda (_) (spotify-client-track-album-tracks ,album))
                                           'help-echo (format "Show %s's tracks" album-name)
 					                                'artist-or-album 'album))
                               (spotify-client-api-get-track-duration-formatted song)

--- a/spotify-client.el
+++ b/spotify-client.el
@@ -4,6 +4,7 @@
 
 ;; Keywords: multimedia, music, spotify, spotify-client
 ;; Package: spotify-client
+;; Package-Requires: ((emacs "24.4") (simple-httpd "1.5") (oauth2 "0.14") (request "0.3"))
 
 ;;; Commentary:
 

--- a/spotify-client.el
+++ b/spotify-client.el
@@ -4,7 +4,7 @@
 
 ;; Keywords: multimedia, music, spotify, spotify-client
 ;; Package: spotify-client
-;; Package-Requires: ((emacs "24.4") (simple-httpd "1.5") (oauth2 "0.14") (request "0.3"))
+;; Package-Requires: ((emacs "24.4") (simple-httpd "1.5") (oauth2 "0.16") (request "0.3"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
I've added a `Package-Requires` header to allow dependencies to be fetched automatically by package managers, and removed the `eval-when-compile` block around `(require 'oauth2)`, which does not seem to be necessary anymore (please let me know if it still causes issues).

I also made some other non-related changes, do let me know if you want me to separate them out:
- use `user-emacs-directory` instead of hardcoding `~/.emacs.d`
- Ensured that `make-empty-file` creates the full path, instead of just erring if the directories were not created